### PR TITLE
remove "Nü Metal Provocateur"

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -577,7 +577,6 @@ Nutty Professor Movie
 Nutty Programming Men
 nuǝɯ pǝɥsᴉꞁod mǝu
 Nybble Processing Mainframe
-Nü Metal Provocateur
 #
 # please don't add your expansions down here!
 # insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
This is an expansion of n**mp**, not n**pm**.

Please disregard if I've somehow gotten my alphabet wrong or if the expansion rules are lax enough to permit this.
